### PR TITLE
Fix issue with Vue template syntax

### DIFF
--- a/src/Modal.vue
+++ b/src/Modal.vue
@@ -1,19 +1,21 @@
 <template>
+    <div>
     <div v-show="visible" class="modal-bg" @click="onBgClick" :style="bgStyle"></div>
-    <div v-el:content class="modal-ct" v-show="visible" :transition="transition" :style="[contentStyle,ctStyle]">
-        <header v-if="!onlyBody" class="modal-ct-head">
-            <p class="modal-ct-title">{{ title }}</p>
-            <button class="delete" @click="hide"></button>
-        </header>
-        <section class="modal-ct-body" :style="bodyStyle">
-            <slot></slot>
-        </section>
-        <footer v-if="!onlyBody" class="modal-ct-foot clearfix">
-            <div class="fright">
-                <a class="button" @click="cancel">{{ cancelText }}</a>
-                <a class="button is-primary" @click="ok">{{ okText }}</a>
-            </div>
-        </footer>
+        <div v-el:content class="modal-ct" v-show="visible" :transition="transition" :style="[contentStyle,ctStyle]">
+            <header v-if="!onlyBody" class="modal-ct-head">
+                <p class="modal-ct-title">{{ title }}</p>
+                <button class="delete" @click="hide"></button>
+            </header>
+            <section class="modal-ct-body" :style="bodyStyle">
+                <slot></slot>
+            </section>
+            <footer v-if="!onlyBody" class="modal-ct-foot clearfix">
+                <div class="fright">
+                    <a class="button" @click="cancel">{{ cancelText }}</a>
+                    <a class="button is-primary" @click="ok">{{ okText }}</a>
+                </div>
+            </footer>
+        </div>
     </div>
 </template>
 


### PR DESCRIPTION
 in ./~/vue-loader/lib/template-compiler.js?id=data-v-c8a470ca!./~/vue-loader/lib/selector.js?type=template&index=0!./~/vue-flexible-modal/src/Modal.vue

  Vue template syntax error:

  Component template should contain exactly one root element:

<div v-show="visible" class="modal-bg" @click="onBgClick" :style="bgStyle"></div>
<div v-el:content class="modal-ct" v-show="visible" :transition="transition" :style="[contentStyle,ctStyle]">
    <header v-if="!onlyBody" class="modal-ct-head">
        <p class="modal-ct-title">{{ title }}</p>
        <button class="delete" @click="hide"></button>
    </header>
    <section class="modal-ct-body" :style="bodyStyle">
        <slot></slot>
    </section>
    <footer v-if="!onlyBody" class="modal-ct-foot clearfix">
        <div class="fright">
            <a class="button" @click="cancel">{{ cancelText }}</a>
            <a class="button is-primary" @click="ok">{{ okText }}</a>
        </div>
    </footer>
</div>

If you are using v-if on multiple elements, use v-else-if to chain them instead.